### PR TITLE
Patch moderation response with self-harm instead of selfharm.

### DIFF
--- a/OpenAI.SDK/ObjectModels/ResponseModels/CreateModerationResponse.cs
+++ b/OpenAI.SDK/ObjectModels/ResponseModels/CreateModerationResponse.cs
@@ -27,7 +27,7 @@ public record Categories
 
     [JsonPropertyName("hatethreatening")] public bool HateThreatening { get; set; }
 
-    [JsonPropertyName("selfharm")] public bool Selfharm { get; set; }
+    [JsonPropertyName("self-harm")] public bool Selfharm { get; set; }
 
     [JsonPropertyName("sexual")] public bool Sexual { get; set; }
 
@@ -44,7 +44,7 @@ public record CategoryScores
 
     [JsonPropertyName("hatethreatening")] public float HateThreatening { get; set; }
 
-    [JsonPropertyName("selfharm")] public float Selfharm { get; set; }
+    [JsonPropertyName("self-harm")] public float Selfharm { get; set; }
 
     [JsonPropertyName("sexual")] public float Sexual { get; set; }
 


### PR DESCRIPTION
The self-harm field comes from the moderation end point with a hyphen in the name. The existing CreateModerationResponse does not contain the hyphen and causing these fields to always default to false and 0.